### PR TITLE
Sanitize terminal escape/control sequences in output renderers

### DIFF
--- a/src/core/output/human.ts
+++ b/src/core/output/human.ts
@@ -1,4 +1,5 @@
 import chalk, { Chalk } from 'chalk';
+import { sanitizeTerminalText } from './sanitize.js';
 
 export interface HumanRenderOptions {
   noColor?: boolean;
@@ -79,24 +80,25 @@ function formatValue(value: unknown, painter: typeof chalk): string {
 }
 
 function formatString(value: string, painter: typeof chalk): string {
-  const lowered = value.toLowerCase();
+  const safeValue = sanitizeTerminalText(value);
+  const lowered = safeValue.toLowerCase();
   if (['running', 'healthy', 'online', 'ok', 'success'].includes(lowered)) {
-    return painter.green(value);
+    return painter.green(safeValue);
   }
 
   if (['stopped', 'offline', 'failed', 'error', 'alert', 'critical', 'fatal'].includes(lowered)) {
-    return painter.red(value);
+    return painter.red(safeValue);
   }
 
   if (['degraded', 'warning', 'pending', 'notice'].includes(lowered)) {
-    return painter.yellow(value);
+    return painter.yellow(safeValue);
   }
 
   if (['info'].includes(lowered)) {
-    return painter.blue(value);
+    return painter.blue(safeValue);
   }
 
-  return value;
+  return safeValue;
 }
 
 function formatNumber(value: number): string {

--- a/src/core/output/sanitize.ts
+++ b/src/core/output/sanitize.ts
@@ -1,0 +1,7 @@
+import { stripVTControlCharacters } from 'node:util';
+
+const CONTROL_CHARACTERS_REGEX = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g;
+
+export function sanitizeTerminalText(value: string): string {
+  return stripVTControlCharacters(value).replace(CONTROL_CHARACTERS_REGEX, '');
+}

--- a/src/core/output/table.ts
+++ b/src/core/output/table.ts
@@ -1,4 +1,5 @@
 import Table from 'cli-table3';
+import { sanitizeTerminalText } from './sanitize.js';
 
 export interface TableRenderOptions {
   quiet?: boolean;
@@ -50,14 +51,14 @@ function renderTableFromObject(data: Record<string, unknown>): string {
 
 function formatCell(value: unknown): string {
   if (Array.isArray(value) || isPlainObject(value)) {
-    return JSON.stringify(value);
+    return sanitizeTerminalText(JSON.stringify(value));
   }
 
   if (value == null) {
     return '';
   }
 
-  return String(value);
+  return sanitizeTerminalText(String(value));
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/tests/unit/core/output.test.ts
+++ b/tests/unit/core/output.test.ts
@@ -75,6 +75,12 @@ describe('renderHuman', () => {
     expect(result).not.toContain('#1');
     expect(result).toContain('name: tower');
   });
+
+  it('sanitizes terminal escape sequences in string values', () => {
+    const result = renderHuman({ message: '\u001b[2J\u001b[Hspoof' }, { noColor: true });
+    expect(result).toContain('message: spoof');
+    expect(result).not.toContain('\u001b[');
+  });
 });
 
 describe('structured renderers', () => {
@@ -108,6 +114,12 @@ describe('structured renderers', () => {
     expect(result).toContain('status');
     expect(result).toContain('disk1');
     expect(result).toContain('disk2');
+  });
+
+  it('sanitizes terminal escape sequences in table cells', () => {
+    const result = renderTable([{ message: '\u001b]52;c;SGVsbG8=\u0007payload' }]);
+    expect(result).toContain('payload');
+    expect(result).not.toContain(']52;c;SGVsbG8=');
   });
 });
 


### PR DESCRIPTION
### Motivation
- The human and table renderers emitted untrusted strings verbatim, allowing ANSI/VT terminal escape sequences from server-provided notification fields to reach operator TTYs and enabling terminal spoofing/clipboard injection.

### Description
- Add a shared sanitizer `sanitizeTerminalText` (`src/core/output/sanitize.ts`) that strips VT control/escape sequences and unsafe control characters.
- Apply sanitization to the human renderer so all string values are sanitized before coloring/formatting (`src/core/output/human.ts`).
- Apply sanitization to table cell formatting so table cells cannot carry escape/control payloads (`src/core/output/table.ts`).
- Add unit tests exercising sanitization for human and table outputs (`tests/unit/core/output.test.ts`).

### Testing
- Ran the unit test file `tests/unit/core/output.test.ts` with `npm run test -- tests/unit/core/output.test.ts` and all tests passed.
- Built the project with `npm run build` and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1bae36e88322b2744c05be47d295)