### PR TITLE
fix(output): sanitize terminal control characters in human renderer

### DIFF
--- a/src/core/output/human.ts
+++ b/src/core/output/human.ts
@@ -79,24 +79,40 @@ function formatValue(value: unknown, painter: typeof chalk): string {
 }
 
 function formatString(value: string, painter: typeof chalk): string {
-  const lowered = value.toLowerCase();
+  const sanitizedValue = sanitizeControlCharacters(value);
+  const lowered = sanitizedValue.toLowerCase();
   if (['running', 'healthy', 'online', 'ok', 'success'].includes(lowered)) {
-    return painter.green(value);
+    return painter.green(sanitizedValue);
   }
 
   if (['stopped', 'offline', 'failed', 'error', 'alert', 'critical', 'fatal'].includes(lowered)) {
-    return painter.red(value);
+    return painter.red(sanitizedValue);
   }
 
   if (['degraded', 'warning', 'pending', 'notice'].includes(lowered)) {
-    return painter.yellow(value);
+    return painter.yellow(sanitizedValue);
   }
 
   if (['info'].includes(lowered)) {
-    return painter.blue(value);
+    return painter.blue(sanitizedValue);
   }
 
-  return value;
+  return sanitizedValue;
+}
+
+function sanitizeControlCharacters(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, (char) => {
+    if (char === '\t') {
+      return '\\t';
+    }
+    if (char === '\n') {
+      return '\\n';
+    }
+    if (char === '\r') {
+      return '\\r';
+    }
+    return `\\x${char.charCodeAt(0).toString(16).padStart(2, '0').toUpperCase()}`;
+  });
 }
 
 function formatNumber(value: number): string {

--- a/tests/unit/core/output.test.ts
+++ b/tests/unit/core/output.test.ts
@@ -75,6 +75,12 @@ describe('renderHuman', () => {
     expect(result).not.toContain('#1');
     expect(result).toContain('name: tower');
   });
+
+  it('escapes terminal control characters in string values', () => {
+    const result = renderHuman({ hostname: '\u001b[31mtower\u001b[0m' }, { noColor: true });
+    expect(result).toContain('hostname: \\x1B[31mtower\\x1B[0m');
+    expect(result).not.toContain('\u001b[');
+  });
 });
 
 describe('structured renderers', () => {


### PR DESCRIPTION
### Motivation
- System command output previously passed server-controlled strings verbatim to the human renderer, allowing ANSI/control sequences (e.g., ESC) to reach a TTY and enabling terminal escape injection. 
- The change aims to neutralize that injection surface while preserving existing readable output and colorization logic.

### Description
- Add `sanitizeControlCharacters` in `src/core/output/human.ts` to escape C0/C1 control bytes (`\x00-\x1F`, `\x7F-\x9F`), preserving readable escapes for `\n`, `\r`, and `\t` and hex-escaping other controls (including ESC). 
- Update `formatString` to use the sanitized value for both returned text and subsequent colorization. 
- Add a unit test in `tests/unit/core/output.test.ts` which verifies that an ESC-based ANSI sequence is rendered as escaped text rather than raw control bytes. 
- Changes are minimal and preserve existing human-formatting behavior for ordinary text and known status words.

### Testing
- Ran `npm test -- --run tests/unit/core/output.test.ts` and the test file passed (17 tests). 
- Ran `npm test -- --run tests/unit/commands/system.test.ts` and the file passed (8 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1bae45f88322b73ac211bbdcae57)