### PR TITLE
Fix #5 and #6: global flags + skillPath

### DIFF
--- a/src/cli/globals.ts
+++ b/src/cli/globals.ts
@@ -104,7 +104,7 @@ export function resolveGlobalOptions(raw: Record<string, unknown>): GlobalOption
     quiet: raw['quiet'] as boolean | undefined,
     yes: raw['yes'] as boolean | undefined,
     force: raw['force'] as boolean | undefined,
-    noColor: raw['noColor'] as boolean | undefined,
+    noColor: (raw['noColor'] as boolean | undefined) ?? (raw['color'] === false ? true : undefined),
   };
 }
 

--- a/src/commands/containers/restart.ts
+++ b/src/commands/containers/restart.ts
@@ -25,11 +25,11 @@ export function createContainersRestartCommand(
     .argument('<container>', 'Container ID or name')
     .action(async function handleContainersRestart(containerArg: string) {
       const options = resolveContainersOptions(this);
-      const localOptions = this.opts<RestartOptions>();
+      const mergedOptions = this.optsWithGlobals<RestartOptions>();
 
       await assertSafety('containers.restart', {
-        yes: localOptions.yes,
-        force: localOptions.force,
+        yes: mergedOptions.yes,
+        force: mergedOptions.force,
       });
 
       const target = await fetchContainer(containerArg, options, dependencies);

--- a/src/commands/containers/write-shared.ts
+++ b/src/commands/containers/write-shared.ts
@@ -35,11 +35,11 @@ export function createContainerWriteCommand(
     .argument('<container>', 'Container ID or name')
     .action(async function handleContainerWrite(containerArg: string) {
       const options = resolveContainersOptions(this);
-      const localOptions = this.opts<WriteCommandOptions>();
+      const mergedOptions = this.optsWithGlobals<WriteCommandOptions>();
 
       await assertSafety(input.safetyPath, {
-        yes: localOptions.yes,
-        force: localOptions.force,
+        yes: mergedOptions.yes,
+        force: mergedOptions.force,
       });
 
       const target = await fetchContainer(containerArg, options, dependencies);


### PR DESCRIPTION
## Summary
- use merged global+local options for container restart safety confirmation
- use merged global+local options for shared container write safety confirmation
- verify marketplace.json already points skillPath to SKILL.md, so no change needed

Closes #5
Closes #6