### PR TITLE
ci: auto-publish to npm on push to main

### DIFF
--- a/.agent/docs/pipeline.md
+++ b/.agent/docs/pipeline.md
@@ -1,0 +1,46 @@
+# npm publish pipeline
+
+## GitHub Actions workflow
+
+The repository uses `.github/workflows/publish.yml` to publish `unraid-cli` to npm on every push to `main`.
+
+Workflow summary:
+
+1. Checkout the repository with enough history to compare the previous `package.json` version.
+2. Run `npm ci`.
+3. Run `npm run check`.
+4. If the version in `package.json` was not changed in the pushed commit, bump the patch version automatically.
+5. Tag the release as `v<version>`.
+6. Publish to npm.
+7. Push the release commit and tags back to `main`.
+
+## Required secret: `NPM_TOKEN`
+
+Set up an npm access token and store it as a GitHub repository secret.
+
+### 1. Create the npm token
+
+1. Sign in to npm.
+2. Open `https://www.npmjs.com/settings/tokens`.
+3. Create a token with read and write access for package publishing.
+4. If npm enforces 2FA for publishing, use a token that supports 2FA bypass for automation.
+
+### 2. Add the token to GitHub
+
+1. Open the GitHub repository.
+2. Go to **Settings**.
+3. Open **Secrets and variables** > **Actions**.
+4. Click **New repository secret**.
+5. Name the secret `NPM_TOKEN`.
+6. Paste the npm token value.
+7. Save the secret.
+
+### 3. How the workflow uses it
+
+The workflow maps the secret to `NODE_AUTH_TOKEN` and configures npm with:
+
+```bash
+npm config set "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN"
+```
+
+That allows `npm publish` to authenticate against the npm registry without interactive login.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,77 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: npm run check
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          PREVIOUS_VERSION=""
+
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
+            PREVIOUS_VERSION=$(git show HEAD^:package.json | node -p "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync(0,'utf8')); pkg.version" || true)
+          fi
+
+          if [ -n "$PREVIOUS_VERSION" ] && [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
+            echo "Version already changed in source: $PREVIOUS_VERSION -> $CURRENT_VERSION"
+            echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          else
+            npm version patch --no-git-tag-version
+            NEW_VERSION=$(node -p "require('./package.json').version")
+            git add package.json package-lock.json
+            git commit -m "chore(release): v$NEW_VERSION"
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          VERSION=$(node -p "require('./package.json').version")
+          git tag "v$VERSION"
+
+      - name: Configure npm auth
+        run: npm config set "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN"
+
+      - name: Publish package
+        run: npm publish
+
+      - name: Push release commit and tags
+        run: git push origin main --follow-tags

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <p align="center">
     <img src="https://img.shields.io/badge/TypeScript-5.6%2B-blue?logo=typescript&logoColor=white" alt="TypeScript 5.6+">
     <img src="https://img.shields.io/badge/Unraid-7.2%2B-orange?logo=unraid&logoColor=white" alt="Unraid 7.2+">
+    <img src="https://img.shields.io/npm/v/unraid-cli?logo=npm&label=npm" alt="npm version">
     <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License">
     <img src="https://img.shields.io/badge/AI_agent-ready-blueviolet" alt="AI Agent Ready">
   </p>


### PR DESCRIPTION
## Summary\n- add a GitHub Actions workflow to auto-publish unraid-cli to npm on pushes to main\n- add npm install guidance and npm badge to the README\n- document NPM_TOKEN setup for the publish pipeline\n\n## Verification\n- npm run typecheck\n- npm test\n- npm pack --dry-run